### PR TITLE
Update Activity package name to new Venmo app package

### DIFF
--- a/VenmoLibrary.java
+++ b/VenmoLibrary.java
@@ -22,7 +22,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 public class VenmoLibrary {
     private static final String VENMO_PACKAGE = "com.venmo";
-    private static final String VENMO_ACTIVITY = "com.venmo.ComposeActivity";
+    private static final String VENMO_ACTIVITY = "com.venmo.controller.ComposeActivity";
 
     public VenmoLibrary() {}
 


### PR DESCRIPTION
This fixes #12. Venmo refactored their activity packages to be within a `controller` package, causing the helper `isVenmoInstalled` method to always return false.
